### PR TITLE
adiçao do match para o envio de mais de um verbo HTTP em uma rota

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -22,6 +22,19 @@ class Router extends Dispatch
     }
 
     /**
+     * @param  array $methods
+     * @param string $route
+     * @param $handler
+     * @param string|null $name
+     */
+    public function match(array $methods, string $route, $handler, string $name = null): void
+    {
+        foreach($methods as $method) {
+            $this->addRoute(strtoupper($method), $route, $handler, $name);
+        }
+    }
+
+    /**
      * @param string $route
      * @param $handler
      * @param string|null $name


### PR DESCRIPTION
Ao trabalhar com o CoffeCode/Router senti falta de poder ter uma rota que aceite mais de um verbo HTTP, então fiz uma pequena adição no seu código, com o método match agora agora se é passado em um array os verbos http que deseja aceitar, a rota ao usar o metodo match fica assim:
$router->match(['post','put'], '/', 'HomeController:index'); 
Espero poder ajudar mais pessoas com esta pequena alteração.
Parabéns pelo incrível trabalho que tem feito, sou muito fã do seu canal no YouTube. 