### PR TITLE
Implement HEAD method

### DIFF
--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -140,7 +140,16 @@ abstract class Dispatch
             if (class_exists($controller)) {
                 $newController = new $controller($this);
                 if (method_exists($controller, $method)) {
+                    if ($this->httpMethod == "HEAD") {
+                        ob_start();
+                    }
+
                     $newController->$method(($this->route['data'] ?? []));
+
+                    if ($this->httpMethod == "HEAD") {
+                        ob_clean();
+                        ob_end_clean();
+                    }
                     return true;
                 }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -39,6 +39,7 @@ class Router extends Dispatch
     public function get(string $route, $handler, string $name = null): void
     {
         $this->addRoute("GET", $route, $handler, $name);
+        $this->addRoute("HEAD", $route, $handler);
     }
 
     /**


### PR DESCRIPTION
When making HEAD requests all output will be buffered to prevent any content trickling into the response body, as defined in [RFC2616 (Hypertext Transfer Protocol -- HTTP/1.1)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4):

> The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response. The metainformation contained in the HTTP headers in response to a HEAD request SHOULD be identical to the information sent in response to a GET request. This method can be used for obtaining metainformation about the entity implied by the request without transferring the entity-body itself. This method is often used for testing hypertext links for validity, accessibility, and recent modification.

To do this, the router adds a HEAD route to all GET routes and in the end removes all body content, returning only the headers.