### PR TITLE
Barra oblíqua [ / ] erro 404

### DIFF
--- a/exemple/page-curse_exemple/.htaccess
+++ b/exemple/page-curse_exemple/.htaccess
@@ -1,0 +1,16 @@
+RewriteEngine On
+Options All -Indexes
+
+# ROUTER WWW Redirect.
+RewriteCond %{HTTP_HOST} !^www\. [NC]
+RewriteRule ^ https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+# ROUTER HTTPS Redirect
+RewriteCond %{HTTP:X-Forwarded-Proto} !https
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+# ROUTER URL Rewrite
+RewriteCond %{SCRIPT_FILENAME} !-f
+RewriteCond %{SCRIPT_FILENAME} !-d
+RewriteRule ^(.*)$ index.php?route=/$1 [L,QSA]

--- a/exemple/page-curse_exemple/index.php
+++ b/exemple/page-curse_exemple/index.php
@@ -1,0 +1,27 @@
+<?php
+require __DIR__ . "/vendor/autoload.php";
+define("URL_BASE", "http://localhost");
+require("./routes.php");
+
+use CoffeeCode\Router\Router;
+
+$router = new Router(URL_BASE);
+
+$router->namespace("RoutesController");
+
+$router->get("/", "web:home");
+$router->get("/home", "web:home");
+$router->get("/about", "web:about");
+$router->get("/contact", "web:contact");
+$router->get("/courses", "web:courses");
+$router->get("/course/{id}", "web:course");
+
+$router->group("error")->namespace("RoutesController");
+$router->get("/{errcode}", "web:http_404");
+
+
+$router->dispatch();
+
+if ($router->error()) {
+    $router->redirect(URL_BASE . "/error/{$router->error()}");
+}

--- a/exemple/page-curse_exemple/routes.php
+++ b/exemple/page-curse_exemple/routes.php
@@ -1,0 +1,134 @@
+<?php
+namespace RoutesController;
+
+class web
+{
+    public $cousers = [
+        [
+            "id" => 2101,
+            "title" => "Learn HTML",
+            "description" => "HTML is the standard markup language for Web pages. With HTML you can create your own Website."
+        ],
+        [
+            "id" => 2102,
+            "title" => "Learn CSS",
+            "description" => "CSS is the language we use to style an HTML document. CSS describes how HTML elements should be displayed."
+        ],
+        [
+            "id" => 2103,
+            "title" => "Learn JavaScript",
+            "description" => "JavaScript is the programming language of the Web."
+        ],
+        [
+            "id" => 2104,
+            "title" => "Learn PHP",
+            "description" => "PHP is a server scripting language, and a powerful tool for making dynamic and interactive Web pages."
+        ]
+    ];
+
+    public function __construct($router)
+    {
+        $this->router = $router;
+    }
+    
+    // functions utils
+    public function header(String $title): void
+    {
+        echo("<h1>$title - Couses123</h1>");
+        echo("<div style='display: flex'>");
+        echo("<div style='margin-right: 10px'><a href='". URL_BASE . "/'>Home</a></div>");
+        echo("<div style='margin-right: 10px'><a href='". URL_BASE . "/courses'>Courses</a></div>");
+        echo("<div style='margin-right: 10px'><a href='". URL_BASE . "/about'>About</a></div>");
+        echo("<div style='margin-right: 10px'><a href='". URL_BASE . "/contact'>Contact</a></div>");
+        echo("</div>");
+        echo("<hr/>");
+    }
+
+    public function footer(): void
+    {
+        echo("<hr/>");
+        echo("<div style='text-align: center'><span>Courses123 - Footer<span></div>");
+    }
+
+    public function getCourse($id)
+    {
+        foreach($this->cousers as $course) {
+            if(array_key_exists('id', $course) && $course['id'] == $id) return $course;
+        }
+        return null;
+    }
+    // 
+
+    public function home(): void
+    {
+        $this->header("Home");
+        echo("<h2>Page Home</h2>");
+        echo("<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aut doloribus esse ea est itaque enim tenetur vero nulla in ut eius qui, veritatis nam, nisi labore aliquam sequi aspernatur ducimus.</p>");
+        echo("<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Veniam exercitationem, vel at officia sed quos. In ea et vitae cupiditate a nobis excepturi! Illum porro eius iusto ducimus, deserunt dolorem.</p>");
+        $this->footer();
+    }
+
+    public function about(): void
+    {
+        $this->header("About");
+        echo("<h2>Page About</h2>");
+        echo("<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aut doloribus esse ea est itaque enim tenetur vero nulla in ut eius qui, veritatis nam, nisi labore aliquam sequi aspernatur ducimus.</p>");
+        echo("<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Veniam exercitationem, vel at officia sed quos. In ea et vitae cupiditate a nobis excepturi! Illum porro eius iusto ducimus, deserunt dolorem.</p>");
+        $this->footer();
+    }
+
+    public function contact(): void
+    {
+        $this->header("Contact");
+        echo("<h2>Page Contact</h2>");
+        echo("<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aut doloribus esse ea est itaque enim tenetur vero nulla in ut eius qui, veritatis nam, nisi labore aliquam sequi aspernatur ducimus.</p>");
+        echo("<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Veniam exercitationem, vel at officia sed quos. In ea et vitae cupiditate a nobis excepturi! Illum porro eius iusto ducimus, deserunt dolorem.</p>");
+        $this->footer();
+    }
+
+    public function courses(): void
+    {
+        $this->header("Courses");
+        echo("<h2>Page Courses</h2>");
+
+        echo("<div style='margin-right: 10px'>COURSE: <a href='". URL_BASE . "/course/2101'>Course HTML</a></div>");
+        echo("<div style='margin-right: 10px'>COURSE: <a href='". URL_BASE . "/course/2102'>Course CSS</a></div>");
+        echo("<div style='margin-right: 10px'>COURSE: <a href='". URL_BASE . "/course/2103'>Course JavaScript</a></div>");
+        echo("<div style='margin-right: 10px'>COURSE: <a href='". URL_BASE . "/course/2104'>Course PHP</a></div>");
+
+        echo("<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aut doloribus esse ea est itaque enim tenetur vero nulla in ut eius qui, veritatis nam, nisi labore aliquam sequi aspernatur ducimus.</p>");
+        echo("<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Veniam exercitationem, vel at officia sed quos. In ea et vitae cupiditate a nobis excepturi! Illum porro eius iusto ducimus, deserunt dolorem.</p>");
+        $this->footer();
+    }
+
+    public function course($req): void
+    {
+        $id = $req['id'];
+        $course = $this->getCourse($id);
+        
+        $this->header("Courses");
+
+        if($course !== null){
+            echo("<h2>" . $course['title'] . "</h2>");
+            echo "<p>". $course['description'] ."</p>";
+            echo "<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. A nihil ea molestiae, labore eligendi neque doloremque ab odit, harum officia deserunt, perspiciatis cupiditate pariatur. Eum harum mollitia dolor nam a.</p>";
+        } else {
+            header("Location: ". URL_BASE ."/error/404");
+        }
+        $this->footer();
+    }
+
+    public function http_404(): void
+    {
+        $this->header("Error 404");
+        echo("<h2>Desculpe essa página não existe</h2>");
+        echo("<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Aut doloribus esse ea est itaque enim tenetur vero nulla in ut eius qui, veritatis nam, nisi labore aliquam sequi aspernatur ducimus.</p>");
+        echo("<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Veniam exercitationem, vel at officia sed quos. In ea et vitae cupiditate a nobis excepturi! Illum porro eius iusto ducimus, deserunt dolorem.</p>");
+        $this->footer();
+    }
+
+    public function redirect(): void
+    {
+        $this->router->redirect("name.hello");
+    }
+}

--- a/src/Dispatch.php
+++ b/src/Dispatch.php
@@ -55,6 +55,7 @@ abstract class Dispatch
     {
         $this->projectUrl = (substr($projectUrl, "-1") == "/" ? substr($projectUrl, 0, -1) : $projectUrl);
         $this->patch = (filter_input(INPUT_GET, "route", FILTER_DEFAULT) ?? "/");
+        $this->patch = rtrim($this->patch, "/");
         $this->separator = ($separator ?? ":");
         $this->httpMethod = $_SERVER['REQUEST_METHOD'];
     }


### PR DESCRIPTION
Estou usando coffeecode/router para fazer o gerenciamento das rotas amigáveis no PHP e recentemente tive um problema com a barra oblíqua no final da URL, quando tinha uma barra no final da URL o Router entende como um erro 404 e lança no error() -> [ int(404) ].

Então para contornar essa situação adicionei uma função nativa do PHP para fazer a retirada dessa barra oblíqua da URL, foi colocado a função "rtrim" dentro do construtor da classe Dispatch que corrige essa questão alterando o $this->patch...

...
$this->patch = rtrim($this->patch, "/");
...

rtrim -> https://www.php.net/manual/pt_BR/function.rtrim.php

Criei também um novo projeto para exemplo prático de uso do coffeecode/router.