### PR TITLE
feat(router): add OPTIONS method for route handling

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -95,4 +95,19 @@ class Router extends Dispatch
     ): void {
         $this->addRoute("DELETE", $route, $handler, $name, $middleware);
     }
+
+    /**
+     * @param string $route
+     * @param callable|string $handler
+     * @param string|null $name
+     * @param array|string|null $middleware
+     */
+    public function options(
+        string $route,
+        callable|string $handler,
+        string $name = null,
+        array|string $middleware = null
+    ): void {
+        $this->addRoute("OPTIONS", $route, $handler, $name, $middleware);
+    }
 }


### PR DESCRIPTION
Em algumas situações o navegador precisa enviar uma requisição preflight de CORS, de método OPTIONS, que verifica se o protocolo CORS é entendido e se o servidor aguarda o método e cabeçalhos especificados. No meu caso concreto, um preflight retornava um 200 OK ou 302 Found (se ligado o redirect de erro) mas não completava a "2a" solicitação do navegador.

Identifiquei que a causa do problema era a falta de um rota OPTIONS homônima a da minha requisição ou um tratamento anterior a isso... então resolvi com um simples if SERVER_METHOD === OPTIONS que passava os cabeçalhos e dava exit, mas também testei a solução que propus no commit.

Não sou experiente, o método sugerido é mais para exemplificar a situação.