### PR TITLE
Fixing formSpoofing

### DIFF
--- a/src/RouterTrait.php
+++ b/src/RouterTrait.php
@@ -62,32 +62,20 @@ trait RouterTrait
      */
     protected function formSpoofing(): void
     {
-        $post = filter_input_array(INPUT_POST, FILTER_DEFAULT);
 
-        if (!empty($post['_method']) && in_array($post['_method'], ["PUT", "PATCH", "DELETE"])) {
-            $this->httpMethod = $post['_method'];
-            $this->data = $post;
+        $methods = ["POST", "PUT", "PATCH", "DELETE"];
+        $this->httpMethod = $_SERVER["REQUEST_METHOD"];
 
-            unset($this->data["_method"]);
+        if (in_array($this->httpMethod, $methods)) {
+            
+            $this->data = filter_var_array(json_decode(file_get_contents('php://input', false, null, 0, $_SERVER['CONTENT_LENGTH']), true), FILTER_DEFAULT) ?? [];
+            
             return;
-        }
 
-        if ($this->httpMethod == "POST") {
-            $this->data = filter_input_array(INPUT_POST, FILTER_DEFAULT);
-
-            unset($this->data["_method"]);
-            return;
-        }
-
-        if (in_array($this->httpMethod, ["PUT", "PATCH", "DELETE"]) && !empty($_SERVER['CONTENT_LENGTH'])) {
-            parse_str(file_get_contents('php://input', false, null, 0, $_SERVER['CONTENT_LENGTH']), $putPatch);
-            $this->data = $putPatch;
-
-            unset($this->data["_method"]);
-            return;
         }
 
         $this->data = [];
+        
     }
 
     /**

--- a/src/RouterTrait.php
+++ b/src/RouterTrait.php
@@ -68,7 +68,7 @@ trait RouterTrait
 
         if (in_array($this->httpMethod, $methods)) {
             
-            $this->data = filter_var_array(json_decode(file_get_contents('php://input', false, null, 0, $_SERVER['CONTENT_LENGTH']), true), FILTER_DEFAULT) ?? [];
+            $this->data = filter_var_array(json_decode(file_get_contents('php://input', false, null, 0, $_SERVER['CONTENT_LENGTH']), true) ?? [], FILTER_DEFAULT) ?? [];
             
             return;
 

--- a/src/RouterTrait.php
+++ b/src/RouterTrait.php
@@ -64,17 +64,29 @@ trait RouterTrait
     {
 
         $methods = ["POST", "PUT", "PATCH", "DELETE"];
+
+        $this->data = filter_input_array(INPUT_POST) ?? [];
         $this->httpMethod = $_SERVER["REQUEST_METHOD"];
 
-        if (in_array($this->httpMethod, $methods)) {
-            
-            $this->data = filter_var_array(json_decode(file_get_contents('php://input', false, null, 0, $_SERVER['CONTENT_LENGTH']), true) ?? [], FILTER_DEFAULT) ?? [];
-            
+        if(isset($this->data["_method"])) {
+
+            $this->httpMethod = $this->data["_method"];
+            unset($this->data["_method"]);
+
             return;
 
         }
 
-        $this->data = [];
+        if (in_array($this->httpMethod, $methods)) {
+            
+            $this->data = [
+                ...$_POST,
+                ...filter_var_array(json_decode(file_get_contents('php://input', false, null, 0, $_SERVER['CONTENT_LENGTH']), true) ?? [], FILTER_DEFAULT) ?? [],
+            ];
+            
+            return;
+
+        }
         
     }
 


### PR DESCRIPTION
Nesta PR, corrigi um problema no formSpoofing que impedia a obtenção correta dos dados enviados via POST, PUT, PATCH e DELETE quando a requisição era originada de um servidor ou domínio diferente. Embora os dados fossem recebidos, não estavam sendo atribuídos corretamente ao body.

Agora, utilizei `file_get_contents("php://input")` para todos os métodos (exceto o GET), juntamente com `filter_var_array` e `json_decode`, de forma similar ao que era feito anteriormente com `filter_input_array` e `parse_str()`.

Peço que revisem essa alteração e me informem se há necessidade de ajustes. Este update é crucial para que eu possa construir uma API que suporte servidores e domínios diferentes.